### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 A Model Context Protocol server for [Scrapybara](https://scrapybara.com). This server enables MCP clients such as [Claude Desktop](https://claude.ai/download), [Cursor](https://www.cursor.com/), and [Windsurf](https://codeium.com/windsurf) to interact with virtual Ubuntu desktops and take actions such as browsing the web, running code, and more.
 
+<a href="https://glama.ai/mcp/servers/g1ig1ibrsc">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/g1ig1ibrsc/badge" alt="Scrapybara MCP server" />
+</a>
+
 ## Prerequisites
 
 - Node.js 18+


### PR DESCRIPTION
This PR adds a badge for the [Scrapybara MCP](https://glama.ai/mcp/servers/g1ig1ibrsc) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/g1ig1ibrsc">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/g1ig1ibrsc/badge" alt="Scrapybara MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.